### PR TITLE
feat: PilotLogging - move options to /Pilot, New logic in SiteDirector

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/PilotLoggingAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PilotLoggingAgent.py
@@ -58,8 +58,8 @@ class PilotLoggingAgent(AgentModule):
         voRes = {}
         for vo in self.voList:
             self.opsHelper = Operations(vo=vo, setup=self.setup)
-            pilotLogging = self.opsHelper.getValue("/Services/JobMonitoring/usePilotsLoggingFlag", False)
-            # is remote pilot logging on for the VO ?
+            # is remote pilot logging enabled for the VO ?
+            pilotLogging = self.opsHelper.getValue("/Pilot/RemoteLogging", True)
             if pilotLogging:
                 res = self.opsHelper.getOptionsDict("/Shifter/DataManager")
                 if not res["OK"]:
@@ -97,17 +97,18 @@ class PilotLoggingAgent(AgentModule):
         """
 
         self.log.info(f"Pilot files upload cycle started for VO: {vo}")
-        uploadSE = self.opsHelper.getValue("/Services/JobMonitoring/UploadSE")
+        uploadSE = self.opsHelper.getValue("/Pilot/UploadSE")
         if uploadSE is None:
             return S_ERROR("Upload SE not defined")
         self.log.info(f"Pilot upload SE: {uploadSE}")
 
-        uploadPath = self.opsHelper.getValue("/Services/JobMonitoring/UploadPath")
+        uploadPath = self.opsHelper.getValue("/Pilot/UploadPath")
         if uploadPath is None:
             return S_ERROR(f"Upload path on SE {uploadSE} not defined")
+        uploadPath = os.path.join("/", vo, uploadPath)
         self.log.info(f"Pilot upload path: {uploadPath}")
 
-        server = self.opsHelper.getValue("/Services/JobMonitoring/DownloadLocation")
+        server = self.opsHelper.getValue("/Pilot/RemoteLoggerURL")
 
         if server is None:
             return S_ERROR(f"No DownloadLocation (server) set in the CS for VO: {vo}!")

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -987,13 +987,13 @@ class SiteDirector(AgentModule):
         else:
             self.log.info("DIRAC project will be installed by pilots")
 
-        # Pilot Logging defined? This enables the extended (possibly remote) logger
-        pilotLogging = opsHelper.getValue("/Services/JobMonitoring/usePilotsLoggingFlag", False)
+        # Pilot Logging defined? This enables the extended (possibly remote) logger.
+        # We need the URL and an optional flag which allows fine tuning on VO by VO basis:
+        pilotLogging = opsHelper.getValue("/Pilot/RemoteLogging", True)
+        remoteLoggerURL = opsHelper.getValue("/Pilot/RemoteLoggerURL", None)
         # -z or --pilotLogging flags enable a remote Logger
-        if pilotLogging:
+        if remoteLoggerURL is not None and pilotLogging:
             pilotOptions.append("--pilotLogging")
-            # remote logger URL.
-            remoteLoggerURL = opsHelper.getValue("/Services/JobMonitoring/remoteLoggerURL", "localhost")
             pilotOptions.append("--loggerURL %s" % remoteLoggerURL)
 
         # python 3 pilots?


### PR DESCRIPTION




BEGINRELEASENOTES

This is a change we discussed. It changes some of the options names, moves them to /Pilot. Remove a redundant `DownloadLocation` option. `UploadPath` gets VO prepended.

I haven't fixed the logging yet, but anything on `info `or higher logs fine from the plugins. I asked a question on Discussion.
ENDRELEASENOTES
